### PR TITLE
rotate the geometry instead of mesh to work with teleport component

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,6 @@ AFRAME.registerComponent('environment', {
     // create ground
     this.groundMaterial = null;
     this.ground = document.createElement('a-entity');
-    this.ground.setAttribute('rotation', '-90 0 0');
     this.ground.classList.add('environmentGround');
     this.groundCanvas = null;
     this.groundTexture = null;
@@ -529,10 +528,11 @@ AFRAME.registerComponent('environment', {
 
       this.groundGeometry.verticesNeedUpdate = true;
       this.groundGeometry.normalsNeedUpdate = true;
+      this.groundGeometry.rotateX(- Math.PI / 2)
     }
 
     // apply Y scale. There's no need to recalculate the geometry for this. Just change scale
-    this.ground.setAttribute('scale', {z: this.data.groundYScale});
+    this.ground.setAttribute('scale', {y: this.data.groundYScale});
 
     // update ground, playarea and grid textures.
     var groundResolution = 2048;

--- a/index.js
+++ b/index.js
@@ -170,6 +170,7 @@ AFRAME.registerComponent('environment', {
     this.groundGeometry = null;
 
     this.dressing = document.createElement('a-entity');
+    this.dressing.classList.add('environmentDressing')
 
     this.gridCanvas = null;
     this.gridTexture = null;


### PR DESCRIPTION
We can now teleport on the hills!
The changes here is needed so the intersect face normal of raycaster is valid for the teleport component, i.e a vector `x: 0, y: 1, z: 0` instead of `x: 0, y: 0, z: 1`.

There is a similar fix in https://github.com/fernandojsg/aframe-teleport-controls/pull/29