### PR TITLE
Update groundMaterial shading

### DIFF
--- a/index.js
+++ b/index.js
@@ -559,12 +559,20 @@ AFRAME.registerComponent('environment', {
 
       // ground material diffuse map is the regular ground texture and the grid texture
       // is used in the emissive map. This way, the grid is always equally visible, even at night.
-      this.groundMaterial = new THREE.MeshLambertMaterial({
+      this.groundMaterialProps = {
         map: this.groundTexture,
         emissive: new THREE.Color(0xFFFFFF),
-        emissiveMap: this.gridTexture,
-        flatShading: this.data.flatShading
-      });
+        emissiveMap: this.gridTexture
+      };
+
+      // use .shading for A-Frame < 0.6.0 and .flatShading for A-Frame >= 0.7.0
+      if (new THREE.Material().hasOwnProperty('shading')) {
+        this.groundMaterialProps.shading = this.data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
+      } else {
+        this.groundMaterialProps.flatShading = this.data.flatShading;
+      }
+
+      this.groundMaterial = new THREE.MeshLambertMaterial(this.groundMaterialProps);
     }
 
     var groundctx = this.groundCanvas.getContext('2d');

--- a/index.js
+++ b/index.js
@@ -563,7 +563,7 @@ AFRAME.registerComponent('environment', {
         map: this.groundTexture,
         emissive: new THREE.Color(0xFFFFFF),
         emissiveMap: this.gridTexture,
-        shading: this.data.flatShading ? THREE.FlatShading : THREE.SmoothShading
+        flatShading: this.data.flatShading
       });
     }
 

--- a/index.js
+++ b/index.js
@@ -565,7 +565,7 @@ AFRAME.registerComponent('environment', {
         emissiveMap: this.gridTexture
       };
 
-      // use .shading for A-Frame < 0.6.0 and .flatShading for A-Frame >= 0.7.0
+      // use .shading for A-Frame < 0.7.0 and .flatShading for A-Frame >= 0.7.0
       if (new THREE.Material().hasOwnProperty('shading')) {
         this.groundMaterialProps.shading = this.data.flatShading ? THREE.FlatShading : THREE.SmoothShading;
       } else {


### PR DESCRIPTION
Suppresses the following warning when using the component with A-Frame v0.7.0:

`THREE.MeshLambertMaterial: .shading has been removed. Use the boolean .flatShading instead.`

`.shading` has been removed and is now `.flatShading`, see: https://threejs.org/docs/index.html#api/materials/Material