### PR TITLE
Fix ground types 'hills' & 'canyon' not using seed

### DIFF
--- a/index.js
+++ b/index.js
@@ -473,7 +473,7 @@ AFRAME.registerComponent('environment', {
       if (!this.groundGeometry) {
         this.groundGeometry = new THREE.PlaneGeometry(this.STAGE_SIZE + 2, this.STAGE_SIZE + 2, resolution - 1, resolution - 1);
       }
-      var perlin = new PerlinNoise();
+      var perlin = new PerlinNoise(this.environmentData.seed);
       var verts = this.groundGeometry.attributes.position.array;
       var numVerts = verts.length;
       var frequency = 10;
@@ -1206,13 +1206,14 @@ AFRAME.registerShader('gradientshader', {
 // perlin noise generator
 // from https://gist.github.com/banksean/304522
 
-var PerlinNoise = function(r) {
-  if (r == undefined) r = Math;
+var PerlinNoise = function(seed) {
+  var randomWithSeed;
   this.grad3 = [[1,1,0],[-1,1,0],[1,-1,0],[-1,-1,0],[1,0,1],[-1,0,1],[1,0,-1],[-1,0,-1],[0,1,1],[0,-1,1],[0,1,-1],[0,-1,-1]];
   this.p = [];
   var i;
   for (i=0; i<256; i++) {
-    this.p[i] = Math.floor(r.random(666)*256);
+    randomWithSeed = parseFloat('0.' + Math.sin(seed * 9999 * i).toString().substr(7));
+    this.p[i] = Math.floor(randomWithSeed * 256);
   }
   // To remove the need for index wrapping, double the permutation table length
   this.perm = [];


### PR DESCRIPTION
There was an issue where the ground types of 'hills' and 'canyon' were not using the seed. Based on issue #44, it seems that the intention was to use the seed to keep the layout consistent similar to the other ground types, 'noise' and 'spikes'. Below is an explanation of the steps I took to fix the issue:

- Added custom seed as a parameter to the `perlin` object in the `updateGround` function
    - With this change, if the case that "hills" or "canyon" are used, the seed is being passed into the `perlin.noise` method.
- In the Perlin Noise Generator, I created a variable called `randomWithSeed` that will be used in the for loop to generate random numbers using the seed.
    - This logic was essentially taken from the `random` function defined earlier in the code
    - In that same for loop, I replaced `r.random(666)` with the new `randomWithSeed` variable
    - Since the `r` variable is no longer used, I simplified the function by removing it as a parameter and as well as the line `if (r == undefined) r = Math;`, which isn't needed.
    - I added `seed` as a parameter so we can pull in the user's custom seed when generating the `randomWithSeed` number.


**Fixes Issues**

- https://github.com/supermedium/aframe-environment-component/issues/32
- https://github.com/supermedium/aframe-environment-component/issues/44