### PR TITLE
Updates to matrix4

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>A-Frame Environment Component</title>
     <meta name="description" content="A-Frame Environment Component">
     <meta name="author" content="Diego F. Goberna">
-    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@9a611ec968ce8edfd2fa7da68ead0fe70dc0c0df/dist/aframe-master.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@090b5f8f0abe949ddcfdbbc14c75822322a2dd53/dist/aframe-master.min.js"></script>
     <script src="dist/aframe-environment-component.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Voces" rel="stylesheet">
 

--- a/index.js
+++ b/index.js
@@ -814,7 +814,7 @@ AFRAME.registerComponent('environment', {
           else shape.lineTo(verts[i], verts[i + 1]);
         }
         geo = new THREE.ExtrudeGeometry(shape, {amount: 1, bevelEnabled: false});
-        geo.applyMatrix(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(-Math.PI / 2, 0, 0)));
+        geo.applyMatrix4(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(-Math.PI / 2, 0, 0)));
         if (data[j]['noise']) applyNoise(geo, data[j].noise);
         geoset.push(geo);
       }
@@ -858,17 +858,17 @@ AFRAME.registerComponent('environment', {
     switch (this.environmentData.dressing){
       case 'cubes': {
         geoset = [new THREE.BoxGeometry(1, 1, 1)];
-        geoset[0].applyMatrix(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
+        geoset[0].applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
         break;
       }
       case 'pyramids': {
         geoset = [new THREE.ConeGeometry(1, 1, 4, 1, true)];
-        geoset[0].applyMatrix(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
+        geoset[0].applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
         break;
       }
       case 'cylinders': {
         geoset = [new THREE.CylinderGeometry(0.5, 0.5, 1, 8, 1, true)];
-        geoset[0].applyMatrix(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
+        geoset[0].applyMatrix4(new THREE.Matrix4().makeTranslation(0, 0.5, 0));
         break;
       }
       default: {


### PR DESCRIPTION
- I noticed that these applyMatrix() calls throw a warning in 1.3.0, and break current master.
- I was not able to get any tests to run, and had to try several versions of node to get an npm install working; almost filed an issue for not being able to npm install, but upgrading to node 16.17.1 did it, finally. Trying to run tests, karma complains a config file is running. Trying to run manually without config file, I get nothing. I did see a guide to contributing, so I assume tests aren't a thing right now; if I need to do something else, let me know.
- I noticed that on the readme, the github.io site is pointing to a page that is on A-Frame 0.7.0. Index.html is not nearly so out of date, though--it points to 1.2.0. You might have github pointed at a gh-pages branch, or have some other configuration error. I went ahead and updated it to 1.3.0, anyways, for now.