### PR TITLE
Use dithering in gradientshader and skyshader to reduce banding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1007,6 +1007,8 @@ AFRAME.registerShader('skyshader', {
   ].join('\n'),
 
   fragmentShader: [
+    '#include <common>',
+    '#include <dithering_pars_fragment>',
     'uniform sampler2D skySampler;',
     'uniform vec3 sunPosition;',
     'varying vec3 vWorldPosition;',
@@ -1169,6 +1171,7 @@ AFRAME.registerShader('skyshader', {
     'gl_FragColor.rgb = retColor;',
 
     'gl_FragColor.a = 1.0;',
+    '#include <dithering_fragment>',
     '}'
   ].join('\n')
 });
@@ -1192,6 +1195,8 @@ AFRAME.registerShader('gradientshader', {
   ].join('\n'),
 
   fragmentShader: [
+    '#include <common>',
+    '#include <dithering_pars_fragment>',
     'uniform vec3 bottomColor;',
     'uniform vec3 topColor;',
     'uniform float offset;',
@@ -1199,6 +1204,7 @@ AFRAME.registerShader('gradientshader', {
     'void main() {',
     ' float h = normalize( vWorldPosition ).y;',
     ' gl_FragColor = vec4( mix( bottomColor, topColor, max( pow( max(h, 0.0 ), 0.8 ), 0.0 ) ), 1.0 );',
+    ' #include <dithering_fragment>',
     '}'
   ].join('\n')
 });


### PR DESCRIPTION
The custom sky shaders for the `gradient` and `atmosphere` sky types can exhibit very noticeable banding. TRHEE.js has shader chunks that perform dithering to reduce this. This PR introduces the dithering in both shaders:

| Before | After |
|-----------|---------|
|![image](https://user-images.githubusercontent.com/8823461/211566557-9ed6b260-8ae6-43ba-b612-6555ae9f777d.png)| ![image](https://user-images.githubusercontent.com/8823461/211566377-a5f46e77-1c50-4e4a-8cda-d6ac435d6f94.png)| 