### PR TITLE
Replace mergeBufferGeometries by mergeGeometries

### DIFF
--- a/index.js
+++ b/index.js
@@ -831,7 +831,7 @@ AFRAME.registerComponent('environment', {
         if (data[j]['mirror']) {
           var mirroredGeo = geo.clone();
           mirroredGeo.applyMatrix4(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, Math.PI, 0)));
-          geo = THREE.BufferGeometryUtils.mergeBufferGeometries([geo, mirroredGeo]);
+          geo = THREE.BufferGeometryUtils.mergeGeometries([geo, mirroredGeo]);
         }
 
         if (data[j]['noise']) applyNoise(geo, data[j].noise);
@@ -936,7 +936,7 @@ AFRAME.registerComponent('environment', {
     }
 
     // convert geometry to buffergeometry
-    var bufgeo = THREE.BufferGeometryUtils.mergeBufferGeometries(geometries);
+    var bufgeo = THREE.BufferGeometryUtils.mergeGeometries(geometries);
     bufgeo.attributes.position.needsUpdate = true;
 
     // setup Materialial


### PR DESCRIPTION
Replace `mergeBufferGeometries` by `mergeGeometries` to remove a warning with aframe master r152.
The renaming was introduced in r151, so this PR is not compatible with aframe 1.4.2.
We may better live with the warning for a while to support both aframe 1.5.0 and aframe 1.4.2 or we could do a check if `THREE.BufferGeometryUtils.mergeGeometries` exists and call it otherwise call `THREE.BufferGeometryUtils.mergeBufferGeometries` if we really want to get rid of the warning and still be compatible with aframe 1.4.2.