### PR TITLE
Replace luminance uniform with exposureBias avoiding name collision with Three.js luminance function

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>A-Frame Environment Component</title>
     <meta name="description" content="A-Frame Environment Component">
     <meta name="author" content="Diego F. Goberna">
-    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@090b5f8f0abe949ddcfdbbc14c75822322a2dd53/dist/aframe-master.min.js"></script>
+    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
     <script src="dist/aframe-environment-component.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Voces" rel="stylesheet">
 

--- a/index.js
+++ b/index.js
@@ -988,7 +988,7 @@ AFRAME.registerComponent('environment', {
 // atmosphere sky shader. From https://github.com/aframevr/aframe/blob/master/examples/test/shaders/shaders/sky.js
 AFRAME.registerShader('skyshader', {
   schema: {
-    luminance: { type: 'number', default: 1, min: 0, max: 2, is: 'uniform' },
+    exposureBias: { type: 'number', default: 1.0, min: 0, max: 10, is: 'uniform' },
     turbidity: { type: 'number', default: 2, min: 0, max: 20, is: 'uniform' },
     reileigh: { type: 'number', default: 1, min: 0, max: 4, is: 'uniform' },
     mieCoefficient: { type: 'number', default: 0.005, min: 0, max: 0.1, is: 'uniform' },
@@ -1015,7 +1015,7 @@ AFRAME.registerShader('skyshader', {
 
     'vec3 cameraPos = vec3(0., 0., 0.);',
 
-    'uniform float luminance;',
+    'uniform float exposureBias;',
     'uniform float turbidity;',
     'uniform float reileigh;',
     'uniform float mieCoefficient;',
@@ -1153,17 +1153,11 @@ AFRAME.registerShader('skyshader', {
 
     'vec3 whiteScale = 1.0/Uncharted2Tonemap(vec3(W));',
 
-    'vec3 texColor = (Lin+L0);   ',
-    'texColor *= 0.04 ;',
+    'vec3 texColor = (Lin+L0);',
+    'texColor *= 0.04;',
     'texColor += vec3(0.0,0.001,0.0025)*0.3;',
 
-    'float g_fMaxLuminance = 1.0;',
-    'float fLumScaled = 0.1 / luminance;     ',
-    'float fLumCompressed = (fLumScaled * (1.0 + (fLumScaled / (g_fMaxLuminance * g_fMaxLuminance)))) / (1.0 + fLumScaled); ',
-
-    'float ExposureBias = fLumCompressed;',
-
-    'vec3 curr = Uncharted2Tonemap((log2(2.0/pow(luminance,4.0)))*texColor);',
+    'vec3 curr = Uncharted2Tonemap(exposureBias*texColor);',
     'vec3 color = curr*whiteScale;',
 
     'vec3 retColor = pow(color,vec3(1.0/(1.2+(1.2*sunfade))));',


### PR DESCRIPTION
This PR replaces the `luminance` uniform in the sky shader for an `exposureBias` uniform. This avoids a name collision with the `luminance` method in newer version of Three.js (part of `common.glsl` shader chunk).

Functionally it serves the same purpose, where `exposureBias` is easier to use for artistic purposes as it linearly adjusts the exposure. This means that lower values result in less exposure, and higher values in higher exposure. This in contrast with the previous `luminance` which was only valid for values between 0.0 and ~1.2, wasn't linear and resulted in less exposure for higher values.

The output is identical as before (with the default value of 1.0), so this PR doesn't change the default appearance of the skyshader. Note that the tone mapping logic isn't quite correct, so terms like "luminance" or "exposure" are as a result also not quite accurate for what they do.

Fixes #87 