### PR TITLE
Specify side back for sky material

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,6 +295,7 @@ AFRAME.registerComponent('environment', {
 
       var mat = {};
       mat.shader = {'none': 'flat', 'color': 'flat', 'gradient': 'gradientshader', 'atmosphere': 'skyshader'}[skyType];
+      mat.side = 'back';
       if (this.stars) {
         this.stars.setAttribute('visible', skyType == 'atmosphere');
       }


### PR DESCRIPTION
In my project with aframe 1.4.2 I didn't see the sky gradient at all with the arches preset, I had to specify `side: back` for the material.
But I don't reproduce on the examples in the repository, that's so weird.
So I don't know if the proposed change is relevant or not.