### PR TITLE
Keep compatibility with aframe 1.4.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -831,7 +831,8 @@ AFRAME.registerComponent('environment', {
         if (data[j]['mirror']) {
           var mirroredGeo = geo.clone();
           mirroredGeo.applyMatrix4(new THREE.Matrix4().makeRotationFromEuler(new THREE.Euler(0, Math.PI, 0)));
-          geo = THREE.BufferGeometryUtils.mergeGeometries([geo, mirroredGeo]);
+          var mergeGeometries = THREE.BufferGeometryUtils.mergeGeometries || THREE.BufferGeometryUtils.mergeBufferGeometries;
+          geo = mergeGeometries([geo, mirroredGeo]);
         }
 
         if (data[j]['noise']) applyNoise(geo, data[j].noise);
@@ -936,7 +937,8 @@ AFRAME.registerComponent('environment', {
     }
 
     // convert geometry to buffergeometry
-    var bufgeo = THREE.BufferGeometryUtils.mergeGeometries(geometries);
+    var mergeGeometries = THREE.BufferGeometryUtils.mergeGeometries || THREE.BufferGeometryUtils.mergeBufferGeometries;
+    var bufgeo = mergeGeometries(geometries);
     bufgeo.attributes.position.needsUpdate = true;
 
     // setup Materialial


### PR DESCRIPTION
#86 introduced incompatible change with aframe 1.4.2.
This PR keeps compatibility with aframe 1.4.2, fallback to mergeBufferGeometries if mergeGeometries is not defined.