### PR TITLE
Set anisotropy of ground and grid texture

### DIFF
--- a/index.js
+++ b/index.js
@@ -599,6 +599,7 @@ AFRAME.registerComponent('environment', {
       this.gridTexture.wrapS = THREE.RepeatWrapping;
       this.gridTexture.wrapT = THREE.RepeatWrapping;
       this.gridTexture.repeat.set(texRepeat, texRepeat);
+      this.gridTexture.anisotropy = 4;
       this.rendererSystem.applyColorCorrection(this.gridTexture);
 
       this.groundCanvas = document.createElement('canvas');
@@ -608,6 +609,7 @@ AFRAME.registerComponent('environment', {
       this.groundTexture.wrapS = THREE.RepeatWrapping;
       this.groundTexture.wrapT = THREE.RepeatWrapping;
       this.groundTexture.repeat.set(texRepeat, texRepeat);
+      this.groundTexture.anisotropy = 4;
       this.rendererSystem.applyColorCorrection(this.groundTexture);
 
       // ground material diffuse map is the regular ground texture and the grid texture


### PR DESCRIPTION
Anisotropy can make the texture sharper in the distance when viewed under a steep angle. With the environment we know the ground and grid textures will be viewed under such conditions, so the visual improvement is substantial. This is also mentioned in the following blog post by Oculus/Meta: [Common Rendering Mistakes: How to Find Them and How to Fix Them](https://developer.oculus.com/blog/common-rendering-mistakes-how-to-find-them-and-how-to-fix-them/)

And in Project Flowerbed they seem to set it for all textures on models they load: [SceneCreationSystem.js#L153](https://github.com/meta-quest/ProjectFlowerbed/blob/6d617d008444e032264d175724a7b4da1ecbab59/src/js/systems/core/SceneCreationSystem.js#L153)

This PR simply sets anisotropy for the two textures used on the ground of the environment. Three.js takes care to not exceed the maximum capabilities of a device. So in case a device doesn't support anisotropy filtering, the setting won't have an effect.

Visual comparison (click to view in full size):
| **default** | **tron** | **japan**|
|-------------------|---------------|----------------|
| ![default](https://github.com/supermedium/aframe-environment-component/assets/8823461/47c90f4e-2fc2-463a-8057-c1f4c2dfc2ec) | ![tron](https://github.com/supermedium/aframe-environment-component/assets/8823461/c882cd47-42d3-4977-b394-71933751b8ba) | ![japan](https://github.com/supermedium/aframe-environment-component/assets/8823461/4f0ce968-1859-4b3c-8c9c-97e557e2918a) |

