### PR TITLE
Remove unused code that is already being removed in minified build

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,6 @@ if (typeof AFRAME === 'undefined') {
   throw new Error('Component attempted to register before AFRAME was available.');
 }
 
-/**
- * enviroGetSettings() - console function for printing out the current environment settings
- */
-function enviroGetSettings () {
-  document.querySelector('[environment]').components['environment'].logPreset();
-}
-
 AFRAME.registerComponent('environment', {
   schema: {
     active: {default: false},
@@ -366,7 +359,7 @@ AFRAME.registerComponent('environment', {
       this.environmentData.playArea != oldData.playArea ||
       this.environmentData.flatShading != oldData.flatShading ||
       this.environmentData.groundDensity != oldData.groundDensity ||
-      this.environmentData.groundFrequency != oldData.groundFrequency
+      this.environmentData.groundFrequency != oldData.groundFrequency ||
       updateStageSize;
 
     // check if any parameter of the ground was changed, and update it
@@ -834,7 +827,6 @@ AFRAME.registerComponent('environment', {
     var geoset = [];
     var self = this;
     function applyNoise(geo, noise) {
-      var n = new THREE.Vector3();
       var verts = geo.attributes.position.array;
       var numVerts = verts.length;
       for (var i = 0; i < numVerts; i+=3) {


### PR DESCRIPTION
When generating a build using `npm run dist`, the following warnings are logged:
```
WARNING in aframe-environment-component.min.js from UglifyJs
Dropping side-effect-free statement [./index.js:370,0]
Side effects in initialization of unused variable n [./index.js:837,0]
Dropping unused function enviroGetSettings [./index.js:10,0]
```

This PR addresses all three of them by removing the offending code. It is technically possible for a user to depend on `enviroGetSettings` when using the non-minified build, but a quick search on GitHub didn't show any usages. Since it's already absent from the minified build, it would be consistent to remove it in the non-minified version as well.