### PR TITLE
Only create stars if needed and dispose them when no longer needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,12 +438,7 @@ AFRAME.registerComponent('environment', {
     }
     this.el.removeChild(this.dressing);
     this.el.removeChild(this.sky);
-    if (this.stars) {
-      var mesh = this.stars.getObject3D('mesh');
-      mesh.material.dispose();
-      mesh.geometry.dispose();
-      this.el.removeChild(this.stars);
-    }
+    this.removeStars();
   },
 
   // logs current parameters to console, for saving to a preset
@@ -1024,16 +1019,32 @@ AFRAME.registerComponent('environment', {
     this.stars.setObject3D('mesh', new THREE.Points(geometry, material));
   },
 
+  // removes and disposes the BufferGeometry of the stars
+  removeStars: function() {
+    if (!this.stars) return;
+
+    var mesh = this.stars.getObject3D('mesh');
+    mesh.material.dispose();
+    mesh.geometry.dispose();
+
+    this.el.removeChild(this.stars);
+    this.stars = null;
+  },
+
   // Sets the number of stars visible. Calls createStars() to initialize if needed.
   setStars: function (numStars) {
-    if (!this.stars){
-      this.stars = document.createElement('a-entity');
-      this.stars.id= 'stars';
-      this.createStars();
-      this.el.appendChild(this.stars);
-    }
     numStars = Math.floor(Math.min(2000, Math.max(0, numStars)));
-    this.stars.getObject3D('mesh').geometry.setDrawRange(0, numStars);
+    if (numStars === 0) {
+      this.removeStars();
+    } else {
+      if (!this.stars) {
+        this.stars = document.createElement('a-entity');
+        this.stars.id = 'stars';
+        this.createStars();
+        this.el.appendChild(this.stars);
+      }
+      this.stars.getObject3D('mesh').geometry.setDrawRange(0, numStars);
+    }
   }
 });
 


### PR DESCRIPTION
When the sky is set to `atmosphere` the stars entity and mesh are generated. However, this also happens if the computed number of stars is 0, which is the case for several of the presets. While nothing is being drawn it still has some drawbacks:

1. Three.js still prepares everything for this draw call (e.g. uniforms), which is just wasted effort
2. The Quest browser logs a warning each frame (`RENDER WARNING: Render count or primcount is 0.`), which after logging 256 warnings stops any further WebGL errors from being logged.

This PR adds an additional check if the star count is 0, in which case the stars aren't created (or even disposed/removed if created prior).