### PR TITLE
Apply 3.14 light intensity scale factor to sunPos contribution as well

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>A-Frame Environment Component</title>
     <meta name="description" content="A-Frame Environment Component">
     <meta name="author" content="Diego F. Goberna">
-    <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="dist/aframe-environment-component.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Voces" rel="stylesheet">
 

--- a/index.js
+++ b/index.js
@@ -286,9 +286,9 @@ AFRAME.registerComponent('environment', {
       else {
         this.hemilight.setAttribute('light', {
           'color': '#CEE4F0',
-          'intensity': 0.314 + sunPos.y * 0.5
+          'intensity': 0.314 + sunPos.y * 1.57
         });
-        this.sunlight.setAttribute('light', {'intensity': 0.314 + sunPos.y * 0.5});
+        this.sunlight.setAttribute('light', {'intensity': 0.314 + sunPos.y * 1.57});
       }
 
       this.sunlight.setAttribute('light', {


### PR DESCRIPTION
Commit 9198c119704851298a09a4ed226b714ed178e34d applied a 3.14 scale factor to the light intensities to compensate for the change in behaviour in Three.js. However, this wasn't applied properly in case of the atmosphere sky type, as the `sunPos.y` contribution to the intensity wasn't scaled.

This PR applies the same scale factor to the `sunPos` contribution. Additionally the A-Frame version in the index.html file is bumped to 1.7.0 as well. Otherwise the resulting environments appear overly bright since the scale factor is only needed in A-Frame 1.7.0 and up.